### PR TITLE
feat: Cria endpoint para listar permissões disponíveis

### DIFF
--- a/companies/urls.py
+++ b/companies/urls.py
@@ -1,9 +1,13 @@
 from django.urls import path
 
 from companies.views.employees import Employees, EmployeeDetail
+from companies.views.permissions import PermissionDetail
 
 urlpatterns = [
     #Employees Endpoints
     path('employees', Employees.as_view()),
-    path('employees/<int:employee_id>', EmployeeDetail.as_view())
+    path('employees/<int:employee_id>', EmployeeDetail.as_view()),
+
+    #Groups And Permissions Endpoints
+    path('permissions', PermissionDetail.as_view()),
 ]

--- a/companies/views/permissions.py
+++ b/companies/views/permissions.py
@@ -1,0 +1,17 @@
+from companies.views.base import Base
+from companies.utils.permissions import GroupsPermission
+from companies.serializers import PermissionsSerializer
+
+from rest_framework.response import Response
+
+from django.contrib.auth.models import Permission
+
+class PermissionDetail(Base):
+    permission_classes = [GroupsPermission]
+
+    def get(self, request):
+        permissions = Permission.objects.filter(content_type_id__in=[2, 7, 11, 13]).all()
+
+        serializer = PermissionsSerializer(permissions, many=True)
+
+        return Response({"permissions": serializer.data})


### PR DESCRIPTION
### Descrição

Este PR introduz um novo endpoint (`GET`) que serve para listar as permissões que podem ser atribuídas aos grupos de usuários.

### Finalidade

O principal objetivo deste endpoint é fornecer ao front-end uma lista de todas as permissões disponíveis no sistema (como "Pode adicionar funcionário", "Pode editar tarefa", etc.). Isso será consumido por uma interface de administração ao criar ou editar um grupo, permitindo que o administrador selecione quais permissões aquele grupo terá.

### Novo Endpoint

| Método | Rota                                | Descrição                                       |
| :----- | :---------------------------------- | :------------------------------------------------ |
| `GET`  | `/api/v1/companies/permissions/`    | Retorna uma lista de objetos de permissão.        |

### Detalhes de Implementação

* A view `PermissionDetail` foi criada para encapsular essa lógica.
* O endpoint é protegido pela permissão `GroupsPermission`, garantindo que apenas usuários que podem gerenciar grupos consigam visualizar a lista de permissões.